### PR TITLE
Scrap inverted_file_grouped

### DIFF
--- a/data.py
+++ b/data.py
@@ -5,8 +5,6 @@ import re
 import csv
 from decimal import Decimal
 
-publisher_re = re.compile(r'(.*)\-[^\-]')
-
 
 # Modified from:
 #   https://github.com/IATI/IATI-Stats/blob/1d20ed1e/stats/common/decorators.py#L5-L13
@@ -22,51 +20,6 @@ def memoize(f):
             self.__cache[key] = res
         return res
     return wrapper
-
-
-class GroupFiles(MutableMapping):
-    def __init__(self, inputdict):
-        self.inputdict = inputdict
-        self.cache = {}
-
-    def __getitem__(self, key):
-        if key in self.cache:
-            return self.cache[key]
-        self.inputdict[key]
-        out = OrderedDict()
-        for k2, v2 in self.inputdict[key].items():
-            if type(v2) == OrderedDict:
-                out[k2] = OrderedDict()
-                for listitem, v3 in v2.items():
-                    m = publisher_re.match(listitem)
-                    if m:
-                        publisher = m.group(1)
-                        if publisher not in out[k2]:
-                            out[k2][publisher] = OrderedDict()
-                        out[k2][publisher][listitem] = v3
-                    else:
-                        pass
-                        # FIXME
-            else:
-                out[k2] = v2
-
-        self.cache[key] = out
-        return out
-
-    def __len__(self):
-        return len(self.inputdict)
-
-    def __iter__(self):
-        return iter(self.inputdict)
-
-    def __delitem__(self, key):
-        try:
-            del self.inputdict[key]
-        except KeyError:
-            pass
-
-    def __setitem__(self, key, value):
-        super(GroupFiles, self).__setitem__(key, value)
 
 
 class JSONDir(MutableMapping):
@@ -224,9 +177,9 @@ current_stats = {
     'aggregated_file': JSONDir('./stats-calculated/current/aggregated-file'),
     'inverted_publisher': JSONDir('./stats-calculated/current/inverted-publisher'),
     'inverted_file': JSONDir('./stats-calculated/current/inverted-file'),
+    'inverted_file_publisher': JSONDir('./stats-calculated/current/inverted-file-publisher'),
     'download_errors': []
 }
-current_stats['inverted_file_grouped'] = GroupFiles(current_stats['inverted_file'])
 ckan_publishers = JSONDir('./data/ckan_publishers')
 ckan = json.load(open('./stats-calculated/ckan.json'), object_pairs_hook=OrderedDict)
 metadata = json.load(open('./stats-calculated/metadata.json'), object_pairs_hook=OrderedDict)

--- a/make_html.py
+++ b/make_html.py
@@ -227,11 +227,9 @@ def element(slug):
     i = slugs['element']['by_slug'][slug]
     element = list(current_stats['inverted_publisher']['elements'])[i]
     publishers = list(current_stats['inverted_publisher']['elements'].values())[i]
-    file_grouped = list(current_stats['inverted_file_grouped']['elements'].values())[i]
     return render_template('element.html',
                            element=element,
                            publishers=publishers,
-                           file_grouped=file_grouped,
                            url=lambda x: '../' + x,
                            page='elements')
 

--- a/templates/element.html
+++ b/templates/element.html
@@ -94,12 +94,16 @@
                 <td>Files</td>
           </thead>
           <tbody>
-            {% for publisher, files in file_grouped.items() %}
+            {% for publisher in current_stats.inverted_file_publisher %}
+              {% with files = current_stats.inverted_file_publisher[publisher].elements[element].keys() %}
+                {% if files %}
                 <tr><td id="files_{{publisher}}"><a href="{{url('publisher/{0}.html'.format(publisher))}}">{{publisher}}</a></td><td>
                 {% for file in files %}
                     <a href="http://iatiregistry.org/dataset/{{file[:-4]}}">{{file[:-4]}}</a>
                 {% endfor %}
                 </td></tr>
+                {% endif %}
+              {% endwith %}
             {% endfor %}
           </tbody>
         </table>

--- a/templates/validation.html
+++ b/templates/validation.html
@@ -19,8 +19,8 @@
 
         <h3>List of files that fail validation, grouped by publisher</h3>
 
-    {% if current_stats.inverted_file_grouped.validation.fail %}
-    {% for publisher,datasets in current_stats.inverted_file_grouped.validation.fail.items() %}
+    {% for publisher in current_stats.inverted_file_publisher %}
+        {% with datasets = current_stats.inverted_file_publisher[publisher].validation.fail.keys() %}
         <div class="panel panel-default">
           <!-- Default panel contents -->
           <div class="panel-heading"><a href="publisher/{{publisher}}.html" id="list_{{publisher}}">{{publisher_name[publisher]}}</a> ({{datasets|length}})</div>
@@ -53,13 +53,10 @@
             {% endfor %}
           </ul>
         </div>
-    {% endfor%}
-    {% else %}
-    <p>There are no files that fail validation.</p>
-    {% endif %}
+        {% endwith %}
+    {% endfor %}
     </div>
 
-    {% if current_stats.inverted_file_grouped.validation.fail %}
     <div class="col-md-6">
 
       <h3>Count of files that fail validation, per publisher.</h3>
@@ -71,16 +68,17 @@
             <th>Failing files <a href="{{stats_url}}/current/inverted-file/validation.json">(J)</a></th>
           </tr></thead>
           <tbody>
-            {% for publisher,datasets in current_stats.inverted_file_grouped.validation.fail.items() %}
-            <tr>
-              <td><a href="#list_{{publisher}}">{{publisher_name[publisher]}}</a></td>
-              <td>{{datasets|length}}</td>
-            </tr>
+            {% for publisher in current_stats.inverted_file_publisher %}
+              {% with datasets = current_stats.inverted_file_publisher[publisher].validation.fail.values() %}
+              <tr>
+                <td><a href="#list_{{publisher}}">{{publisher_name[publisher]}}</a></td>
+                <td>{{datasets|length}}</td>
+              </tr>
+              {% endwith %}
             {% endfor %}
           </tbody>
         </table>
       </div>
     </div>
-    {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
It’s not possible to split a publisher name out from a dataset name,
because hyphens and underscores can be used in both parts. Also, we
don’t actually need to do it – we can just use inverted_file_publisher
instead.

Fixes #27.